### PR TITLE
Fix shell escaping bug for AppleScript execution

### DIFF
--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -1,6 +1,4 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-const execAsync = promisify(exec);
+import { executeAppleScript } from '../../utils/scriptExecution.js';
 
 // Interface for task creation parameters
 export interface AddOmniFocusTaskParams {
@@ -144,16 +142,12 @@ export async function addOmniFocusTask(params: AddOmniFocusTaskParams): Promise<
 
     // Generate AppleScript
     const script = generateAppleScript(params);
-    
-    console.error("Executing AppleScript directly...");
-    
-    // Execute AppleScript directly
-    const { stdout, stderr } = await execAsync(`osascript -e '${script}'`);
-    
-    if (stderr) {
-      console.error("AppleScript stderr:", stderr);
-    }
-    
+
+    console.error("Executing AppleScript...");
+
+    // Execute AppleScript using temp file (avoids shell escaping issues)
+    const stdout = await executeAppleScript(script);
+
     console.error("AppleScript stdout:", stdout);
     
     // Parse the result

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -1,6 +1,4 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-const execAsync = promisify(exec);
+import { executeAppleScript } from '../../utils/scriptExecution.js';
 
 // Interface for project creation parameters
 export interface AddProjectParams {
@@ -95,16 +93,12 @@ export async function addProject(params: AddProjectParams): Promise<{success: bo
   try {
     // Generate AppleScript
     const script = generateAppleScript(params);
-    
-    console.error("Executing AppleScript directly...");
-    
-    // Execute AppleScript directly
-    const { stdout, stderr } = await execAsync(`osascript -e '${script}'`);
-    
-    if (stderr) {
-      console.error("AppleScript stderr:", stderr);
-    }
-    
+
+    console.error("Executing AppleScript...");
+
+    // Execute AppleScript using temp file (avoids shell escaping issues)
+    const stdout = await executeAppleScript(script);
+
     console.error("AppleScript stdout:", stdout);
     
     // Parse the result

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -1,6 +1,4 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-const execAsync = promisify(exec);
+import { executeAppleScript } from '../../utils/scriptExecution.js';
 
 // Status options for tasks and projects
 type TaskStatus = 'incomplete' | 'completed' | 'dropped';
@@ -334,21 +332,17 @@ export async function editItem(params: EditItemParams): Promise<{
   try {
     // Generate AppleScript
     const script = generateAppleScript(params);
-    
+
     console.error("Executing AppleScript for editing...");
     console.error(`Item type: ${params.itemType}, ID: ${params.id || 'not provided'}, Name: ${params.name || 'not provided'}`);
-    
+
     // Log a preview of the script for debugging (first few lines)
     const scriptPreview = script.split('\n').slice(0, 10).join('\n') + '\n...';
     console.error("AppleScript preview:\n", scriptPreview);
-    
-    // Execute AppleScript directly
-    const { stdout, stderr } = await execAsync(`osascript -e '${script}'`);
-    
-    if (stderr) {
-      console.error("AppleScript stderr:", stderr);
-    }
-    
+
+    // Execute AppleScript using temp file (avoids shell escaping issues)
+    const stdout = await executeAppleScript(script);
+
     console.error("AppleScript stdout:", stdout);
     
     // Parse the result

--- a/src/tools/primitives/getTaskById.ts
+++ b/src/tools/primitives/getTaskById.ts
@@ -1,6 +1,4 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-const execAsync = promisify(exec);
+import { executeAppleScript } from '../../utils/scriptExecution.js';
 
 // Interface for task lookup parameters
 export interface GetTaskByIdParams {
@@ -98,16 +96,12 @@ export async function getTaskById(params: GetTaskByIdParams): Promise<{success: 
 
     // Generate AppleScript
     const script = generateGetTaskScript(params);
-    
+
     console.error("Executing getTaskById AppleScript...");
-    
-    // Execute AppleScript
-    const { stdout, stderr } = await execAsync(`osascript -e '${script}'`);
-    
-    if (stderr) {
-      console.error("AppleScript stderr:", stderr);
-    }
-    
+
+    // Execute AppleScript using temp file (avoids shell escaping issues)
+    const stdout = await executeAppleScript(script);
+
     console.error("AppleScript stdout:", stdout);
     
     // Parse the result

--- a/src/tools/primitives/removeItem.ts
+++ b/src/tools/primitives/removeItem.ts
@@ -1,6 +1,4 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-const execAsync = promisify(exec);
+import { executeAppleScript } from '../../utils/scriptExecution.js';
 
 // Interface for item removal parameters
 export interface RemoveItemParams {
@@ -94,21 +92,17 @@ export async function removeItem(params: RemoveItemParams): Promise<{success: bo
   try {
     // Generate AppleScript
     const script = generateAppleScript(params);
-    
+
     console.error("Executing AppleScript for removal...");
     console.error(`Item type: ${params.itemType}, ID: ${params.id || 'not provided'}, Name: ${params.name || 'not provided'}`);
-    
+
     // Log a preview of the script for debugging (first few lines)
     const scriptPreview = script.split('\n').slice(0, 10).join('\n') + '\n...';
     console.error("AppleScript preview:\n", scriptPreview);
-    
-    // Execute AppleScript directly
-    const { stdout, stderr } = await execAsync(`osascript -e '${script}'`);
-    
-    if (stderr) {
-      console.error("AppleScript stderr:", stderr);
-    }
-    
+
+    // Execute AppleScript using temp file (avoids shell escaping issues)
+    const stdout = await executeAppleScript(script);
+
     console.error("AppleScript stdout:", stdout);
     
     // Parse the result


### PR DESCRIPTION
## Problem

When task names contain apostrophes (e.g., "Watch Kelsey's talk"), the `osascript` command fails with:

```
/bin/sh: -c: line 48: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 51: syntax error: unexpected end of file
```

This happens because:
1. The current code escapes quotes with backslashes: `Kelsey\'s`
2. But the script is wrapped in single quotes: `osascript -e '...'`
3. Inside single quotes in bash, backslash escaping doesn't work - the `'` terminates the outer quote

## Solution

Add an `executeAppleScript()` helper function that writes the script to a temp file before execution (following the same pattern as the existing `executeJXA()` function). This completely avoids shell escaping issues.

## Changes

1. **src/utils/scriptExecution.ts**: Add `executeAppleScript()` helper
2. **src/tools/primitives/getTaskById.ts**: Use new helper
3. **src/tools/primitives/addOmniFocusTask.ts**: Use new helper
4. **src/tools/primitives/addProject.ts**: Use new helper
5. **src/tools/primitives/editItem.ts**: Use new helper
6. **src/tools/primitives/removeItem.ts**: Use new helper

## Testing

- Build passes with `npm run build`
- Tasks with apostrophes in names should now work correctly