### PR TITLE
Fix ISO date format parsing for OmniFocus tasks and projects

### DIFF
--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { formatDateForAppleScript } from '../../utils/dateFormatter.js';
 const execAsync = promisify(exec);
 
 // Interface for task creation parameters
@@ -23,8 +24,9 @@ function generateAppleScript(params: AddOmniFocusTaskParams): string {
   // Sanitize and prepare parameters for AppleScript
   const name = params.name.replace(/['"\\]/g, '\\$&'); // Escape quotes and backslashes
   const note = params.note?.replace(/['"\\]/g, '\\$&') || '';
-  const dueDate = params.dueDate || '';
-  const deferDate = params.deferDate || '';
+  // Convert ISO dates to AppleScript format
+  const dueDate = params.dueDate ? formatDateForAppleScript(params.dueDate) : '';
+  const deferDate = params.deferDate ? formatDateForAppleScript(params.deferDate) : '';
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
@@ -69,12 +71,8 @@ function generateAppleScript(params: AddOmniFocusTaskParams): string {
         
         -- Set task properties
         ${note ? `set note of newTask to "${note}"` : ''}
-        ${dueDate ? `
-          set due date of newTask to (current date) + (time to GMT)
-          set due date of newTask to date "${dueDate}"` : ''}
-        ${deferDate ? `
-          set defer date of newTask to (current date) + (time to GMT)
-          set defer date of newTask to date "${deferDate}"` : ''}
+        ${dueDate ? `set due date of newTask to date "${dueDate}"` : ''}
+        ${deferDate ? `set defer date of newTask to date "${deferDate}"` : ''}
         ${flagged ? `set flagged of newTask to true` : ''}
         ${estimatedMinutes ? `set estimated minutes of newTask to ${estimatedMinutes}` : ''}
         

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { formatDateForAppleScript } from '../../utils/dateFormatter.js';
 const execAsync = promisify(exec);
 
 // Interface for project creation parameters
@@ -22,8 +23,9 @@ function generateAppleScript(params: AddProjectParams): string {
   // Sanitize and prepare parameters for AppleScript
   const name = params.name.replace(/['"\\]/g, '\\$&'); // Escape quotes and backslashes
   const note = params.note?.replace(/['"\\]/g, '\\$&') || '';
-  const dueDate = params.dueDate || '';
-  const deferDate = params.deferDate || '';
+  // Convert ISO dates to AppleScript format
+  const dueDate = params.dueDate ? formatDateForAppleScript(params.dueDate) : '';
+  const deferDate = params.deferDate ? formatDateForAppleScript(params.deferDate) : '';
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
@@ -51,12 +53,8 @@ function generateAppleScript(params: AddProjectParams): string {
         
         -- Set project properties
         ${note ? `set note of newProject to "${note}"` : ''}
-        ${dueDate ? `
-          set due date of newProject to (current date) + (time to GMT)
-          set due date of newProject to date "${dueDate}"` : ''}
-        ${deferDate ? `
-          set defer date of newProject to (current date) + (time to GMT)
-          set defer date of newProject to date "${deferDate}"` : ''}
+        ${dueDate ? `set due date of newProject to date "${dueDate}"` : ''}
+        ${deferDate ? `set defer date of newProject to date "${deferDate}"` : ''}
         ${flagged ? `set flagged of newProject to true` : ''}
         ${estimatedMinutes ? `set estimated minutes of newProject to ${estimatedMinutes}` : ''}
         ${`set sequential of newProject to ${sequential}`}

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { formatDateForAppleScript } from '../../utils/dateFormatter.js';
 const execAsync = promisify(exec);
 
 // Status options for tasks and projects
@@ -118,9 +119,10 @@ function generateAppleScript(params: EditItemParams): string {
           set end of changedProperties to "due date"
 `;
     } else {
+      const formattedDueDate = formatDateForAppleScript(params.newDueDate);
       script += `
           -- Update due date
-          set due date of foundItem to (current date) + ((((date "${params.newDueDate}") - (current date)) / days) * days)
+          set due date of foundItem to date "${formattedDueDate}"
           set end of changedProperties to "due date"
 `;
     }
@@ -134,9 +136,10 @@ function generateAppleScript(params: EditItemParams): string {
           set end of changedProperties to "defer date"
 `;
     } else {
+      const formattedDeferDate = formatDateForAppleScript(params.newDeferDate);
       script += `
           -- Update defer date
-          set defer date of foundItem to (current date) + ((((date "${params.newDeferDate}") - (current date)) / days) * days)
+          set defer date of foundItem to date "${formattedDeferDate}"
           set end of changedProperties to "defer date"
 `;
     }

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,0 +1,39 @@
+/**
+ * Utility functions for date formatting
+ */
+
+/**
+ * Convert ISO date string (YYYY-MM-DD or full ISO format) to AppleScript-compatible format
+ *
+ * AppleScript expects dates in the format "D Month YYYY" (e.g., "9 January 2026")
+ * ISO format (YYYY-MM-DD) is incorrectly parsed by AppleScript's date command
+ *
+ * @param isoDate ISO date string (e.g., "2026-01-09" or "2026-01-09T12:00:00")
+ * @returns AppleScript-compatible date string (e.g., "9 January 2026")
+ * @throws Error if the date string is invalid
+ */
+export function formatDateForAppleScript(isoDate: string): string {
+	if (!isoDate || isoDate.trim() === '') {
+		throw new Error('Date string cannot be empty');
+	}
+
+	// Parse the ISO date string
+	const date = new Date(isoDate);
+
+	// Check if the date is valid
+	if (isNaN(date.getTime())) {
+		throw new Error(`Invalid date string: ${isoDate}`);
+	}
+
+	// English month names (AppleScript requires English regardless of system locale)
+	const months = [
+		'January', 'February', 'March', 'April', 'May', 'June',
+		'July', 'August', 'September', 'October', 'November', 'December'
+	];
+
+	const day = date.getDate();
+	const month = months[date.getMonth()];
+	const year = date.getFullYear();
+
+	return `${day} ${month} ${year}`;
+}


### PR DESCRIPTION
## Problem
AppleScript requires dates in "D Month YYYY" format (e.g., "9 January 2026"), but the MCP server was accepting ISO format dates (YYYY-MM-DD) without conversion, causing incorrect date parsing in OmniFocus.

## Solution
Added a date formatter utility that converts ISO dates to the AppleScript-compatible format before passing them to AppleScript commands.

## Changes
- Added `src/utils/dateFormatter.ts` - utility function to convert ISO dates to AppleScript format
- Updated `addOmniFocusTask.ts` - convert due/defer dates before creating tasks
- Updated `addProject.ts` - convert due/defer dates before creating projects  
- Updated `editItem.ts` - convert dates when editing tasks/projects

## Testing
Tested with various date scenarios including due dates, defer dates, and date modifications. All dates now parse correctly in OmniFocus.

## Backward Compatibility
The formatter accepts both ISO format (YYYY-MM-DD) and the existing AppleScript format (D Month YYYY), ensuring backward compatibility with any existing usage.