### PR TITLE
fix: Use locale-independent AppleScript date construction

### DIFF
--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -1,5 +1,5 @@
 import { executeAppleScript } from '../../utils/scriptExecution.js';
-import { formatDateForAppleScript } from '../../utils/dateFormatter.js';
+import { generateAppleScriptDateCode } from '../../utils/dateFormatter.js';
 
 // Interface for project creation parameters
 export interface AddProjectParams {
@@ -21,9 +21,9 @@ function generateAppleScript(params: AddProjectParams): string {
   // Sanitize and prepare parameters for AppleScript
   const name = params.name.replace(/['"\\]/g, '\\$&'); // Escape quotes and backslashes
   const note = params.note?.replace(/['"\\]/g, '\\$&') || '';
-  // Convert ISO dates to AppleScript format
-  const dueDate = params.dueDate ? formatDateForAppleScript(params.dueDate) : '';
-  const deferDate = params.deferDate ? formatDateForAppleScript(params.deferDate) : '';
+  // Generate locale-independent date code
+  const dueDateCode = params.dueDate ? generateAppleScriptDateCode(params.dueDate, "projectDueDate") : '';
+  const deferDateCode = params.deferDate ? generateAppleScriptDateCode(params.deferDate, "projectDeferDate") : '';
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
@@ -33,6 +33,9 @@ function generateAppleScript(params: AddProjectParams): string {
   // Construct AppleScript with error handling
   let script = `
   try
+    -- Build date objects OUTSIDE the tell block (avoids permission issues)
+    ${dueDateCode}
+    ${deferDateCode}
     tell application "OmniFocus"
       tell front document
         -- Determine the container (root or folder)
@@ -51,8 +54,12 @@ function generateAppleScript(params: AddProjectParams): string {
         
         -- Set project properties
         ${note ? `set note of newProject to "${note}"` : ''}
-        ${dueDate ? `set due date of newProject to date "${dueDate}"` : ''}
-        ${deferDate ? `set defer date of newProject to date "${deferDate}"` : ''}
+        ${dueDateCode ? `
+        -- Set due date (using pre-built date object)
+        set due date of newProject to projectDueDate` : ''}
+        ${deferDateCode ? `
+        -- Set defer date (using pre-built date object)
+        set defer date of newProject to projectDeferDate` : ''}
         ${flagged ? `set flagged of newProject to true` : ''}
         ${estimatedMinutes ? `set estimated minutes of newProject to ${estimatedMinutes}` : ''}
         ${`set sequential of newProject to ${sequential}`}

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -5,8 +5,12 @@
 /**
  * Convert ISO date string (YYYY-MM-DD or full ISO format) to AppleScript-compatible format
  *
+ * @deprecated Use generateAppleScriptDateCode instead for locale-independent date handling
+ * 
  * AppleScript expects dates in the format "D Month YYYY" (e.g., "9 January 2026")
  * ISO format (YYYY-MM-DD) is incorrectly parsed by AppleScript's date command
+ * 
+ * WARNING: This function is locale-dependent and may fail on non-English systems.
  *
  * @param isoDate ISO date string (e.g., "2026-01-09" or "2026-01-09T12:00:00")
  * @returns AppleScript-compatible date string (e.g., "9 January 2026")
@@ -36,4 +40,75 @@ export function formatDateForAppleScript(isoDate: string): string {
 	const year = date.getFullYear();
 
 	return `${day} ${month} ${year}`;
+}
+
+/**
+ * Parse an ISO date string and return its components
+ * 
+ * @param isoDate ISO date string (e.g., "2026-01-09" or "2026-01-09T12:00:00")
+ * @returns Object with year, month (1-12), day, hours, minutes, seconds
+ * @throws Error if the date string is invalid
+ */
+export function parseDateComponents(isoDate: string): {
+	year: number;
+	month: number;
+	day: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+} {
+	if (!isoDate || isoDate.trim() === '') {
+		throw new Error('Date string cannot be empty');
+	}
+
+	// Parse the ISO date string
+	const date = new Date(isoDate);
+
+	// Check if the date is valid
+	if (isNaN(date.getTime())) {
+		throw new Error(`Invalid date string: ${isoDate}`);
+	}
+
+	return {
+		year: date.getFullYear(),
+		month: date.getMonth() + 1, // JavaScript months are 0-indexed, AppleScript uses 1-12
+		day: date.getDate(),
+		hours: date.getHours(),
+		minutes: date.getMinutes(),
+		seconds: date.getSeconds()
+	};
+}
+
+/**
+ * Generate AppleScript code to construct a date object in a locale-independent way
+ * 
+ * This approach uses date arithmetic instead of string parsing, which works
+ * regardless of the user's system locale settings.
+ * 
+ * @param isoDate ISO date string (e.g., "2026-01-09" or "2026-01-09T17:30:00")
+ * @param variableName The AppleScript variable name to assign the date to
+ * @returns AppleScript code that creates the date object
+ * @throws Error if the date string is invalid
+ * 
+ * @example
+ * // Returns AppleScript code like:
+ * // set theDueDate to (current date)
+ * // set year of theDueDate to 2026
+ * // set month of theDueDate to 1
+ * // set day of theDueDate to 29
+ * // set hours of theDueDate to 17
+ * // set minutes of theDueDate to 30
+ * // set seconds of theDueDate to 0
+ * generateAppleScriptDateCode("2026-01-29T17:30:00", "theDueDate")
+ */
+export function generateAppleScriptDateCode(isoDate: string, variableName: string): string {
+	const components = parseDateComponents(isoDate);
+	
+	return `set ${variableName} to (current date)
+          set year of ${variableName} to ${components.year}
+          set month of ${variableName} to ${components.month}
+          set day of ${variableName} to ${components.day}
+          set hours of ${variableName} to ${components.hours}
+          set minutes of ${variableName} to ${components.minutes}
+          set seconds of ${variableName} to ${components.seconds}`;
 }


### PR DESCRIPTION
## Summary
Fixes AppleScript date parsing errors that occur on non-English macOS systems or when the system locale doesn't match the expected date format.

## Problem
AppleScript's `date` string parsing is locale-dependent. The previous code used:

```applescript
set due date of foundItem to date "29 January 2026"
```

This fails with error `script error: Invalid date and time date 29 January 2026. (-30720)` on systems where the locale expects different date formats.

## Solution

Implemented locale-independent date construction using AppleScript date arithmetic:

```applescript
set newDueDate to (current date)
set year of newDueDate to 2026
set month of newDueDate to 1
set day of newDueDate to 29
set hours of newDueDate to 0
set minutes of newDueDate to 0
set seconds of newDueDate to 0
set due date of foundItem to newDueDate
```

Additionally, moved date construction **outside** the `tell application "OmniFocus"` block to avoid permission error `-1723 "Access not allowed"`.

## Files Changed

- `src/utils/dateFormatter.ts` - Added `generateAppleScriptDateCode()` and `parseDateComponents()` functions
- `src/tools/primitives/editItem.ts` - Updated date handling
- `src/tools/primitives/addOmniFocusTask.ts` - Updated date handling
- `src/tools/primitives/addProject.ts` - Updated date handling

## Benefits

- Works for all users regardless of macOS locale/language settings
- Preserves time components (hours, minutes) when provided in ISO format
- More robust - no ambiguity in date interpretation

---

**Compare:** [main...rockydev:omnifocus-mcp-enhanced:fix/locale-independent-date-handling](https://github.com/jqlts1/omnifocus-mcp-enhanced/compare/main...rockydev:omnifocus-mcp-enhanced:fix/locale-independent-date-handling)
