### PR TITLE
Return entity IDs in add_project, add_omnifocus_task, batch_add_items

### DIFF
--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -48,7 +48,7 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       return {
         content: [{
           type: "text" as const,
-          text: `✅ Task "${args.name}" created successfully ${locationText}${dueDateText}${plannedDateText}${tagText}.`
+          text: `✅ Task "${args.name}" created successfully ${locationText}${dueDateText}${plannedDateText}${tagText}.\n\nid: ${result.taskId}`
         }]
       };
     } else {

--- a/src/tools/definitions/addProject.ts
+++ b/src/tools/definitions/addProject.ts
@@ -45,7 +45,7 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       return {
         content: [{
           type: "text" as const,
-          text: `✅ Project "${args.name}" created successfully ${locationText}${dueDateText}${plannedDateText}${tagText}${sequentialText}.`
+          text: `✅ Project "${args.name}" created successfully ${locationText}${dueDateText}${plannedDateText}${tagText}${sequentialText}.\n\nid: ${result.projectId}`
         }]
       };
     } else {

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -45,7 +45,7 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
         if (item.success) {
           const itemType = args.items[index].type;
           const itemName = args.items[index].name;
-          return `- ✅ ${itemType}: "${itemName}"`;
+          return `- ✅ ${itemType}: "${itemName}" (id: ${item.id})`;
         } else {
           const itemType = args.items[index].type;
           const itemName = args.items[index].name;


### PR DESCRIPTION
## Summary

- `add_project` now includes `id: <projectId>` in the success response
- `add_omnifocus_task` now includes `id: <taskId>` in the success response  
- `batch_add_items` now includes `(id: <id>)` per successful item in the details list

The primitive layer already captures these IDs from AppleScript — this change simply surfaces them in the MCP tool response text so clients can reference newly created entities without fragile name-based lookups.

Closes #24

## Test plan

- [ ] Create a project via `add_project` → response should include the OmniFocus project ID
- [ ] Create a task via `add_omnifocus_task` → response should include the task ID
- [ ] Create items via `batch_add_items` → each successful item line should show its ID
- [ ] Verify returned IDs match via `get_task_by_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)