### PR TITLE
feat: add project review fields and get_projects /   get_projects_due_for_review tools

### DIFF
--- a/src/omnifocustypes.ts
+++ b/src/omnifocustypes.ts
@@ -79,6 +79,10 @@ export interface ProjectMinimal extends DatabaseObject {
   parentFolder: FolderMinimal | null;
   tags: TagMinimal[];
   tasks: TaskMinimal[];
+  // Review fields (OmniFocus native)
+  nextReviewDate: Date | null;
+  lastReviewDate: Date | null;
+  reviewInterval: any; // OmniFocus Project.ReviewInterval object
 }
 export interface FolderMinimal extends DatabaseObject {
   name: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,9 @@ import * as getForecastTasksTool from './tools/definitions/getForecastTasks.js';
 import * as getTasksByTagTool from './tools/definitions/getTasksByTag.js';
 // Import ultimate filter tool
 import * as filterTasksTool from './tools/definitions/filterTasks.js';
+// Import project tools
+import * as getProjectsTool from './tools/definitions/getProjects.js';
+import * as getProjectsDueForReviewTool from './tools/definitions/getProjectsDueForReview.js';
 // Import custom perspective tools
 import * as listCustomPerspectivesTool from './tools/definitions/listCustomPerspectives.js';
 import * as getCustomPerspectiveTasksTool from './tools/definitions/getCustomPerspectiveTasks.js';
@@ -146,6 +149,21 @@ server.tool(
   "Advanced task filtering with unlimited perspective combinations - status, dates, projects, tags, search, and more",
   filterTasksTool.schema.shape,
   filterTasksTool.handler
+);
+
+// Project tools
+server.tool(
+  "get_projects",
+  "List OmniFocus projects with optional status/folder filtering. Returns project metadata including review dates (nextReviewDate, lastReviewDate, reviewInterval). Lighter than dump_database — returns only projects, no tasks/folders/tags.",
+  getProjectsTool.schema.shape,
+  getProjectsTool.handler,
+);
+
+server.tool(
+  "get_projects_due_for_review",
+  "Get OmniFocus projects that are due for review (nextReviewDate <= now). Returns projects sorted by most overdue first. Use for weekly review project health checks.",
+  getProjectsDueForReviewTool.schema.shape,
+  getProjectsDueForReviewTool.handler,
 );
 
 // Custom perspective tools

--- a/src/tools/definitions/getProjects.ts
+++ b/src/tools/definitions/getProjects.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { getProjects } from "../primitives/getProjects.js";
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+
+export const schema = z.object({
+  status: z
+    .array(z.enum(["Active", "OnHold", "Done", "Dropped"]))
+    .optional()
+    .describe(
+      "Filter by project status. OR logic — matches any. Default: all statuses.",
+    ),
+  folderName: z
+    .string()
+    .optional()
+    .describe("Filter by folder name (case-insensitive partial match)."),
+  includeReviewData: z
+    .boolean()
+    .optional()
+    .describe(
+      "Include review fields (nextReviewDate, lastReviewDate, reviewInterval). Default: true.",
+    ),
+});
+
+export async function handler(
+  args: z.infer<typeof schema>,
+  extra: RequestHandlerExtra,
+) {
+  try {
+    const result = await getProjects({
+      status: args.status,
+      folderName: args.folderName,
+      includeReviewData: args.includeReviewData !== false,
+    });
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: result,
+        },
+      ],
+    };
+  } catch (err: unknown) {
+    const errorMessage =
+      err instanceof Error ? err.message : "Unknown error occurred";
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error getting projects: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/definitions/getProjectsDueForReview.ts
+++ b/src/tools/definitions/getProjectsDueForReview.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { getProjectsDueForReview } from "../primitives/getProjectsDueForReview.js";
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+
+export const schema = z.object({
+  includeOnHold: z
+    .boolean()
+    .optional()
+    .describe("Include on-hold projects in results. Default: false."),
+});
+
+export async function handler(
+  args: z.infer<typeof schema>,
+  extra: RequestHandlerExtra,
+) {
+  try {
+    const result = await getProjectsDueForReview({
+      includeOnHold: args.includeOnHold || false,
+    });
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: result,
+        },
+      ],
+    };
+  } catch (err: unknown) {
+    const errorMessage =
+      err instanceof Error ? err.message : "Unknown error occurred";
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error getting projects due for review: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/dumpDatabase.ts
+++ b/src/tools/dumpDatabase.ts
@@ -164,7 +164,10 @@ export async function dumpDatabase(): Promise<OmnifocusDatabase> {
           note: String(project.note || ""),
           tasks: project.tasks || [],
           flagged: false, // Default value
-          estimatedMinutes: null // Default value
+          estimatedMinutes: null, // Default value
+          nextReviewDate: null,
+          lastReviewDate: null,
+          reviewInterval: null
         };
       }
     }

--- a/src/tools/primitives/getProjects.ts
+++ b/src/tools/primitives/getProjects.ts
@@ -1,0 +1,96 @@
+import { executeOmniFocusScript } from "../../utils/scriptExecution.js";
+
+export interface GetProjectsOptions {
+  status?: string[];
+  folderName?: string;
+  includeReviewData?: boolean;
+}
+
+export async function getProjects(
+  options: GetProjectsOptions = {},
+): Promise<string> {
+  const { status, folderName, includeReviewData = true } = options;
+
+  try {
+    const result = await executeOmniFocusScript("@getProjects.js", {
+      statusFilter: status || null,
+      folderFilter: folderName || null,
+      includeReviewData: includeReviewData,
+    });
+
+    if (typeof result === "string") {
+      return result;
+    }
+
+    if (result && typeof result === "object") {
+      const data = result as any;
+
+      if (data.error) {
+        throw new Error(data.error);
+      }
+
+      let output = `## Projects`;
+
+      // Add filter summary
+      const filters: string[] = [];
+      if (status && status.length > 0)
+        filters.push(`status: ${status.join(", ")}`);
+      if (folderName) filters.push(`folder: ${folderName}`);
+      if (filters.length > 0) {
+        output += ` (${filters.join("; ")})`;
+      }
+      output += `\n\n`;
+
+      if (data.projects && Array.isArray(data.projects)) {
+        if (data.projects.length === 0) {
+          output += "No projects found matching filters.\n";
+        } else {
+          output += `Found ${data.projects.length} project${data.projects.length === 1 ? "" : "s"}:\n\n`;
+
+          data.projects.forEach((proj: any) => {
+            const statusBadge = proj.status === "OnHold" ? " [OnHold]" : "";
+            const flagSymbol = proj.flagged ? " 🚩" : "";
+            const folderStr = proj.folderName
+              ? ` 📁 ${proj.folderName}`
+              : "";
+            const dueDateStr = proj.dueDate
+              ? ` [due: ${new Date(proj.dueDate).toLocaleDateString()}]`
+              : "";
+
+            output += `P: ${proj.name}${statusBadge}${flagSymbol}${folderStr} (${proj.taskCount} tasks)${dueDateStr}\n`;
+            output += `   ID: ${proj.id}\n`;
+
+            if (includeReviewData && proj.nextReviewDate) {
+              const nextReview = new Date(
+                proj.nextReviewDate,
+              ).toLocaleDateString();
+              const lastReview = proj.lastReviewDate
+                ? new Date(proj.lastReviewDate).toLocaleDateString()
+                : "never";
+              const interval = proj.reviewInterval
+                ? `every ${proj.reviewInterval.steps} ${proj.reviewInterval.unit}`
+                : "no interval set";
+              output += `   Review: next ${nextReview}, last ${lastReview}, ${interval}\n`;
+            }
+
+            if (proj.note && proj.note.trim()) {
+              const notePreview = proj.note.trim().substring(0, 100);
+              output += `   Note: ${notePreview}${proj.note.trim().length > 100 ? "..." : ""}\n`;
+            }
+
+            output += "\n";
+          });
+        }
+      }
+
+      return output;
+    }
+
+    return "Unexpected result format from OmniFocus";
+  } catch (error) {
+    console.error("Error in getProjects:", error);
+    throw new Error(
+      `Failed to get projects: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}

--- a/src/tools/primitives/getProjectsDueForReview.ts
+++ b/src/tools/primitives/getProjectsDueForReview.ts
@@ -1,0 +1,75 @@
+import { executeOmniFocusScript } from "../../utils/scriptExecution.js";
+
+export interface GetProjectsDueForReviewOptions {
+  includeOnHold?: boolean;
+}
+
+export async function getProjectsDueForReview(
+  options: GetProjectsDueForReviewOptions = {},
+): Promise<string> {
+  const { includeOnHold = false } = options;
+
+  try {
+    const result = await executeOmniFocusScript("@getProjectsDueForReview.js", {
+      includeOnHold: includeOnHold,
+    });
+
+    if (typeof result === "string") {
+      return result;
+    }
+
+    if (result && typeof result === "object") {
+      const data = result as any;
+
+      if (data.error) {
+        throw new Error(data.error);
+      }
+
+      let output = `## Projects Due for Review\n\n`;
+
+      if (data.projects && Array.isArray(data.projects)) {
+        if (data.projects.length === 0) {
+          output += "No projects are currently due for review.\n";
+        } else {
+          output += `${data.projects.length} project${data.projects.length === 1 ? "" : "s"} due for review:\n\n`;
+
+          data.projects.forEach((proj: any) => {
+            const nextReview = proj.nextReviewDate
+              ? new Date(proj.nextReviewDate).toLocaleDateString()
+              : "unknown";
+            const lastReview = proj.lastReviewDate
+              ? new Date(proj.lastReviewDate).toLocaleDateString()
+              : "never";
+            const interval = proj.reviewInterval
+              ? `every ${proj.reviewInterval.steps} ${proj.reviewInterval.unit}`
+              : "no interval";
+            const folderStr = proj.folderName
+              ? ` 📁 ${proj.folderName}`
+              : "";
+            const statusBadge = proj.status === "OnHold" ? " [OnHold]" : "";
+
+            output += `P: ${proj.name}${statusBadge}${folderStr} (${proj.taskCount} tasks)\n`;
+            output += `   ID: ${proj.id}\n`;
+            output += `   Review: was due ${nextReview}, last reviewed ${lastReview}, ${interval}\n`;
+
+            if (proj.note && proj.note.trim()) {
+              const notePreview = proj.note.trim().substring(0, 100);
+              output += `   Note: ${notePreview}${proj.note.trim().length > 100 ? "..." : ""}\n`;
+            }
+
+            output += "\n";
+          });
+        }
+      }
+
+      return output;
+    }
+
+    return "Unexpected result format from OmniFocus";
+  } catch (error) {
+    console.error("Error in getProjectsDueForReview:", error);
+    throw new Error(
+      `Failed to get projects due for review: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,14 @@ export interface OmnifocusProject {
   tasks: string[]; // Task IDs
   flagged?: boolean;
   estimatedMinutes?: number | null;
+  // Review fields
+  nextReviewDate: string | null;
+  lastReviewDate: string | null;
+  reviewInterval: {
+    steps: number;
+    unit: "days" | "weeks" | "months" | "years";
+    fixed: boolean;
+  } | null;
 }
 
 export interface OmnifocusFolder {

--- a/src/utils/omnifocusScripts/getProjects.js
+++ b/src/utils/omnifocusScripts/getProjects.js
@@ -1,0 +1,98 @@
+(() => {
+  try {
+    // Read parameters from injectedArgs (injected by executeOmniFocusScript)
+    const statusFilter = injectedArgs ? injectedArgs.statusFilter : null;
+    const folderFilter = injectedArgs ? injectedArgs.folderFilter : null;
+    const includeReview = injectedArgs ? (injectedArgs.includeReviewData !== false) : true;
+
+    const projectStatusMap = {
+      [Project.Status.Active]: "Active",
+      [Project.Status.Done]: "Done",
+      [Project.Status.Dropped]: "Dropped",
+      [Project.Status.OnHold]: "OnHold",
+    };
+
+    function formatDate(date) {
+      if (!date) return null;
+      return date.toISOString();
+    }
+
+    function getEnumValue(enumVal, map) {
+      return map[enumVal] || "Unknown";
+    }
+
+    const allProjects = flattenedProjects;
+    let filtered = allProjects;
+
+    // Apply status filter if provided
+    if (statusFilter && statusFilter.length > 0) {
+      const statusSet = new Set(statusFilter);
+      filtered = filtered.filter((p) =>
+        statusSet.has(getEnumValue(p.status, projectStatusMap)),
+      );
+    }
+
+    // Apply folder filter if provided
+    if (folderFilter) {
+      filtered = filtered.filter(
+        (p) =>
+          p.parentFolder &&
+          p.parentFolder.name
+            .toLowerCase()
+            .includes(folderFilter.toLowerCase()),
+      );
+    }
+
+    const projects = [];
+    filtered.forEach((project) => {
+      try {
+        const data = {
+          id: project.id.primaryKey,
+          name: project.name,
+          status: getEnumValue(project.status, projectStatusMap),
+          folderName: project.parentFolder ? project.parentFolder.name : null,
+          folderID: project.parentFolder
+            ? project.parentFolder.id.primaryKey
+            : null,
+          sequential: project.task ? project.task.sequential || false : false,
+          dueDate: formatDate(project.dueDate),
+          deferDate: formatDate(project.deferDate),
+          effectiveDueDate: formatDate(project.effectiveDueDate),
+          effectiveDeferDate: formatDate(project.effectiveDeferDate),
+          completedByChildren: project.completedByChildren || false,
+          containsSingletonActions: project.containsSingletonActions || false,
+          note: project.note || "",
+          taskCount: project.tasks ? project.tasks.length : 0,
+          flagged: project.flagged || false,
+        };
+
+        if (includeReview) {
+          data.nextReviewDate = formatDate(project.nextReviewDate);
+          data.lastReviewDate = formatDate(project.lastReviewDate);
+          data.reviewInterval = project.reviewInterval
+            ? {
+                steps: project.reviewInterval.steps,
+                unit: String(project.reviewInterval.unit),
+                fixed: project.reviewInterval.fixed || false,
+              }
+            : null;
+        }
+
+        projects.push(data);
+      } catch (projError) {
+        // Skip projects that error during extraction
+      }
+    });
+
+    return JSON.stringify({
+      exportDate: new Date().toISOString(),
+      count: projects.length,
+      projects: projects,
+    });
+  } catch (error) {
+    return JSON.stringify({
+      success: false,
+      error: String(error),
+    });
+  }
+})();

--- a/src/utils/omnifocusScripts/getProjectsDueForReview.js
+++ b/src/utils/omnifocusScripts/getProjectsDueForReview.js
@@ -1,0 +1,85 @@
+(() => {
+  try {
+    const onHold = injectedArgs ? injectedArgs.includeOnHold : false;
+
+    const projectStatusMap = {
+      [Project.Status.Active]: "Active",
+      [Project.Status.Done]: "Done",
+      [Project.Status.Dropped]: "Dropped",
+      [Project.Status.OnHold]: "OnHold",
+    };
+
+    function formatDate(date) {
+      if (!date) return null;
+      return date.toISOString();
+    }
+
+    function getEnumValue(enumVal, map) {
+      return map[enumVal] || "Unknown";
+    }
+
+    const now = new Date();
+
+    const dueForReview = flattenedProjects.filter((project) => {
+      if (!project.nextReviewDate || project.nextReviewDate > now) return false;
+      const status = getEnumValue(project.status, projectStatusMap);
+      if (status === "Done" || status === "Dropped") return false;
+      if (status === "OnHold" && !onHold) return false;
+      return true;
+    });
+
+    // Sort by nextReviewDate ascending (most overdue first)
+    dueForReview.sort((a, b) => {
+      if (!a.nextReviewDate) return 1;
+      if (!b.nextReviewDate) return -1;
+      return a.nextReviewDate - b.nextReviewDate;
+    });
+
+    const projects = [];
+    dueForReview.forEach((project) => {
+      try {
+        projects.push({
+          id: project.id.primaryKey,
+          name: project.name,
+          status: getEnumValue(project.status, projectStatusMap),
+          folderName: project.parentFolder ? project.parentFolder.name : null,
+          folderID: project.parentFolder
+            ? project.parentFolder.id.primaryKey
+            : null,
+          sequential: project.task ? project.task.sequential || false : false,
+          dueDate: formatDate(project.dueDate),
+          deferDate: formatDate(project.deferDate),
+          effectiveDueDate: formatDate(project.effectiveDueDate),
+          effectiveDeferDate: formatDate(project.effectiveDeferDate),
+          completedByChildren: project.completedByChildren || false,
+          containsSingletonActions: project.containsSingletonActions || false,
+          note: project.note || "",
+          taskCount: project.tasks ? project.tasks.length : 0,
+          flagged: project.flagged || false,
+          nextReviewDate: formatDate(project.nextReviewDate),
+          lastReviewDate: formatDate(project.lastReviewDate),
+          reviewInterval: project.reviewInterval
+            ? {
+                steps: project.reviewInterval.steps,
+                unit: String(project.reviewInterval.unit),
+                fixed: project.reviewInterval.fixed || false,
+              }
+            : null,
+        });
+      } catch (projError) {
+        // Skip
+      }
+    });
+
+    return JSON.stringify({
+      exportDate: new Date().toISOString(),
+      count: projects.length,
+      projects: projects,
+    });
+  } catch (error) {
+    return JSON.stringify({
+      success: false,
+      error: String(error),
+    });
+  }
+})();


### PR DESCRIPTION
  Summary

  OmniFocus exposes project review scheduling via its Omni Automation API
  (nextReviewDate, lastReviewDate, reviewInterval), but there's currently no way to
  access this data through the MCP server. This PR adds:

  - get_projects — List/filter projects with full metadata including review dates.
  Lighter than dump_database (returns only projects, no tasks/folders/tags).
  Supports optional status and folderName filters.
  - get_projects_due_for_review — Returns projects where nextReviewDate <= now,
  sorted by most overdue first. Useful for weekly review workflows.
  - Review fields added to OmnifocusProject and ProjectMinimal interfaces:
  nextReviewDate, lastReviewDate, reviewInterval (steps, unit, fixed).

  Motivation

  There's no dedicated project query tool in the current server — the only way to
  get project data is parsing it out of dump_database. For AI-assisted GTD workflows
   (weekly reviews, project health checks, staleness detection), having direct
  access to OF's review scheduling data and a lightweight project query tool is
  essential.

  Changes

  - New: src/tools/definitions/getProjects.ts + primitive + OmniJS script
  - New: src/tools/definitions/getProjectsDueForReview.ts + primitive + OmniJS
  script
  - Modified: src/types.ts, src/omnifocustypes.ts (added review fields to project
  interfaces)
  - Modified: src/server.ts (registered new tools)
  - Not modified: dump_database or any existing tools

  Testing

  Verified on OmniFocus 4 (macOS):
  - get_projects returns all projects with review fields populated
  - get_projects_due_for_review correctly filters to overdue projects
  - reviewInterval.unit returns lowercase strings: "days", "weeks", "months",
  "years"
  - No impact on existing tools