### PR TITLE
Expose OmniFocus added dates in dump_database

### DIFF
--- a/src/omnifocustypes.ts
+++ b/src/omnifocustypes.ts
@@ -48,6 +48,7 @@ export interface TaskMinimal extends DatabaseObject {
   note: string;
   flagged: boolean;
   taskStatus: Task.Status;
+  added: Date | null;
   dueDate: Date | null;
   deferDate: Date | null;
   plannedDate: Date | null;
@@ -67,6 +68,7 @@ export interface ProjectMinimal extends DatabaseObject {
   name: string;
   note: string;
   status: Project.Status;
+  added: Date | null;
   dueDate: Date | null;
   deferDate: Date | null;
   plannedDate: Date | null;

--- a/src/tools/definitions/dumpDatabase.test.ts
+++ b/src/tools/definitions/dumpDatabase.test.ts
@@ -118,3 +118,50 @@ test('formatCompactReport includes planned date marker for tasks', () => {
 
   assert.match(output, /PLAN:2\/20/);
 });
+
+test('formatCompactReport includes added date markers for tasks and projects', () => {
+  assert.equal(typeof formatCompactReport, 'function');
+
+  const output = formatCompactReport(
+    {
+      exportDate: '2026-02-12T00:00:00.000Z',
+      tasks: [
+        {
+          id: 'task-added-1',
+          name: 'Review quarterly goals',
+          projectId: 'project-added-1',
+          parentId: null,
+          childIds: [],
+          completed: false,
+          taskStatus: 'Available',
+          flagged: false,
+          addedDate: '2026-02-10T09:00:00.000Z',
+          dueDate: null,
+          deferDate: null,
+          plannedDate: null,
+          estimatedMinutes: null,
+          tagNames: []
+        }
+      ],
+      projects: {
+        'project-added-1': {
+          id: 'project-added-1',
+          name: 'Quarterly planning',
+          status: 'Active',
+          folderID: null,
+          flagged: false,
+          addedDate: '2026-02-01T09:00:00.000Z'
+        }
+      },
+      folders: {},
+      tags: {}
+    },
+    {
+      hideCompleted: true,
+      hideRecurringDuplicates: true
+    }
+  );
+
+  assert.match(output, /P: Quarterly planning \[ADD:2\/1\]/);
+  assert.match(output, /Review quarterly goals \[ADD:2\/10\]/);
+});

--- a/src/tools/definitions/dumpDatabase.ts
+++ b/src/tools/definitions/dumpDatabase.ts
@@ -56,7 +56,7 @@ export function formatCompactReport(database: any, options: { hideCompleted: boo
   // Add legend
   output += `FORMAT LEGEND:
 F: Folder | P: Project | •: Task | 🚩: Flagged
-Dates: [M/D] | [DUE:M/D] [PLAN:M/D] [defer:M/D] | Duration: (30m) or (2h) | Tags: <tag1,tag2>
+Dates: [M/D] | [ADD:M/D] [DUE:M/D] [PLAN:M/D] [defer:M/D] | Duration: (30m) or (2h) | Tags: <tag1,tag2>
 Status: #next #avail #block #due #over #compl #drop\n\n`;
   
   // Map of folder IDs to folder objects for quick lookup
@@ -134,6 +134,11 @@ Status: #next #avail #block #due #over #compl #drop\n\n`;
     }
     
     // Add due date if present
+    if (project.addedDate) {
+      const addedDateStr = formatCompactDate(project.addedDate);
+      statusInfo += ` [ADD:${addedDateStr}]`;
+    }
+
     if (project.dueDate) {
       const dueDateStr = formatCompactDate(project.dueDate);
       statusInfo += statusInfo ? ` [DUE:${dueDateStr}]` : ` [DUE:${dueDateStr}]`;
@@ -178,6 +183,10 @@ Status: #next #avail #block #due #over #compl #drop\n\n`;
     
     // Format dates
     let dateInfo = '';
+    if (task.addedDate) {
+      const addedDateStr = formatCompactDate(task.addedDate);
+      dateInfo += ` [ADD:${addedDateStr}]`;
+    }
     if (task.dueDate) {
       const dueDateStr = formatCompactDate(task.dueDate);
       dateInfo += ` [DUE:${dueDateStr}]`;

--- a/src/tools/dumpDatabase.test.ts
+++ b/src/tools/dumpDatabase.test.ts
@@ -68,3 +68,61 @@ test('normalizeOmnifocusDumpData preserves task and project added dates', () => 
   assert.equal(database.tasks[0].addedDate, taskAddedDate);
   assert.equal(database.projects['project-1'].addedDate, projectAddedDate);
 });
+
+test('normalizeOmnifocusDumpData does not validate added date format', () => {
+  const taskAddedDate = 'not-an-iso-date';
+  const projectAddedDate = 'also-not-an-iso-date';
+
+  const database = normalizeOmnifocusDumpData({
+    exportDate: '2026-05-28T00:00:00.000Z',
+    tasks: [
+      {
+        id: 'task-1',
+        name: 'Review quarterly goals',
+        addedDate: taskAddedDate,
+        note: '',
+        taskStatus: 'Available',
+        flagged: false,
+        dueDate: null,
+        deferDate: null,
+        plannedDate: null,
+        effectiveDueDate: null,
+        effectiveDeferDate: null,
+        effectivePlannedDate: null,
+        estimatedMinutes: null,
+        completedByChildren: false,
+        sequential: false,
+        tags: [],
+        projectID: 'project-1',
+        parentTaskID: null,
+        children: [],
+        inInbox: false
+      }
+    ],
+    projects: {
+      'project-1': {
+        id: 'project-1',
+        name: 'Quarterly planning',
+        addedDate: projectAddedDate,
+        status: 'Active',
+        folderID: null,
+        sequential: false,
+        effectiveDueDate: null,
+        effectiveDeferDate: null,
+        effectivePlannedDate: null,
+        dueDate: null,
+        deferDate: null,
+        plannedDate: null,
+        completedByChildren: false,
+        containsSingletonActions: false,
+        note: '',
+        tasks: ['task-1']
+      }
+    },
+    folders: {},
+    tags: {}
+  });
+
+  assert.equal(database.tasks[0].addedDate, taskAddedDate);
+  assert.equal(database.projects['project-1'].addedDate, projectAddedDate);
+});

--- a/src/tools/dumpDatabase.test.ts
+++ b/src/tools/dumpDatabase.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeOmnifocusDumpData } from './dumpDatabase.js';
+
+test('normalizeOmnifocusDumpData preserves task and project added dates', () => {
+  const taskAddedDate = '2026-05-20T10:30:00.000Z';
+  const projectAddedDate = '2026-05-01T09:00:00.000Z';
+
+  const database = normalizeOmnifocusDumpData({
+    exportDate: '2026-05-28T00:00:00.000Z',
+    tasks: [
+      {
+        id: 'task-1',
+        name: 'Review quarterly goals',
+        addedDate: taskAddedDate,
+        note: '',
+        taskStatus: 'Available',
+        flagged: false,
+        dueDate: null,
+        deferDate: null,
+        plannedDate: null,
+        effectiveDueDate: null,
+        effectiveDeferDate: null,
+        effectivePlannedDate: null,
+        estimatedMinutes: null,
+        completedByChildren: false,
+        sequential: false,
+        tags: ['tag-1'],
+        projectID: 'project-1',
+        parentTaskID: null,
+        children: [],
+        inInbox: false
+      }
+    ],
+    projects: {
+      'project-1': {
+        id: 'project-1',
+        name: 'Quarterly planning',
+        addedDate: projectAddedDate,
+        status: 'Active',
+        folderID: null,
+        sequential: false,
+        effectiveDueDate: null,
+        effectiveDeferDate: null,
+        effectivePlannedDate: null,
+        dueDate: null,
+        deferDate: null,
+        plannedDate: null,
+        completedByChildren: false,
+        containsSingletonActions: false,
+        note: '',
+        tasks: ['task-1']
+      }
+    },
+    folders: {},
+    tags: {
+      'tag-1': {
+        id: 'tag-1',
+        name: 'Planning',
+        parentTagID: null,
+        active: true,
+        allowsNextAction: true,
+        tasks: ['task-1']
+      }
+    }
+  });
+
+  assert.equal(database.tasks[0].addedDate, taskAddedDate);
+  assert.equal(database.projects['project-1'].addedDate, projectAddedDate);
+});

--- a/src/tools/dumpDatabase.ts
+++ b/src/tools/dumpDatabase.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 interface OmnifocusDumpTask {
   id: string;
   name: string;
+  addedDate?: string | null;
   note?: string;
   taskStatus: string;
   flagged: boolean;
@@ -31,6 +32,7 @@ interface OmnifocusDumpTask {
 interface OmnifocusDumpProject {
   id: string;
   name: string;
+  addedDate?: string | null;
   status: string;
   folderID: string | null;
   sequential: boolean;
@@ -72,132 +74,137 @@ interface OmnifocusDumpData {
   tags: Record<string, OmnifocusDumpTag>;
 }
 
-// Main function to dump the database
-export async function dumpDatabase(): Promise<OmnifocusDatabase> {
-  
-  try {
-    // Execute the OmniFocus script
-    const data = await executeOmniFocusScript('@omnifocusDump.js') as OmnifocusDumpData;
-    // wait 1 second
-    await new Promise(resolve => setTimeout(resolve, 1000));
- 
-    // Create an empty database if no data returned
-    if (!data) {
-      return {
-        exportDate: new Date().toISOString(),
-        tasks: [],
-        projects: {},
-        folders: {},
-        tags: {}
-      };
-    }
-    
-    // Initialize the database object
-    const database: OmnifocusDatabase = {
-      exportDate: data.exportDate,
+export function normalizeOmnifocusDumpData(data: OmnifocusDumpData | null | undefined): OmnifocusDatabase {
+  // Create an empty database if no data returned
+  if (!data) {
+    return {
+      exportDate: new Date().toISOString(),
       tasks: [],
       projects: {},
       folders: {},
       tags: {}
     };
-    
-    // Process tasks
-    if (data.tasks && Array.isArray(data.tasks)) {
-      // Convert the tasks to our OmnifocusTask format
-      database.tasks = data.tasks.map((task: OmnifocusDumpTask) => {
-        // Get tag names from the tag IDs
-        const tagNames = (task.tags || []).map(tagId => {
-          return data.tags[tagId]?.name || 'Unknown Tag';
-        });
-        
-        return {
-          id: String(task.id),
-          name: String(task.name),
-          note: String(task.note || ""),
-          flagged: Boolean(task.flagged),
-          completed: task.taskStatus === "Completed",
-          completionDate: null, // Not available in the new format
-          dropDate: null, // Not available in the new format
-          taskStatus: String(task.taskStatus),
-          active: task.taskStatus !== "Completed" && task.taskStatus !== "Dropped",
-          dueDate: task.dueDate,
-          deferDate: task.deferDate,
-          plannedDate: task.plannedDate,
-          estimatedMinutes: task.estimatedMinutes ? Number(task.estimatedMinutes) : null,
-          tags: task.tags || [],
-          tagNames: tagNames,
-          parentId: task.parentTaskID || null,
-          containingProjectId: task.projectID || null,
-          projectId: task.projectID || null,
-          childIds: task.children || [],
-          hasChildren: (task.children && task.children.length > 0) || false,
-          sequential: Boolean(task.sequential),
-          completedByChildren: Boolean(task.completedByChildren),
-          isRepeating: false, // Not available in the new format
-          repetitionMethod: null, // Not available in the new format 
-          repetitionRule: null, // Not available in the new format
-          attachments: normalizeTaskAttachments(task.attachments, task.linkedFileURLs),
-          linkedFileURLs: task.linkedFileURLs || [],
-          notifications: [], // Default empty array
-          shouldUseFloatingTimeZone: false // Default value
-        };
+  }
+
+  // Initialize the database object
+  const database: OmnifocusDatabase = {
+    exportDate: data.exportDate,
+    tasks: [],
+    projects: {},
+    folders: {},
+    tags: {}
+  };
+
+  // Process tasks
+  if (data.tasks && Array.isArray(data.tasks)) {
+    // Convert the tasks to our OmnifocusTask format
+    database.tasks = data.tasks.map((task: OmnifocusDumpTask) => {
+      // Get tag names from the tag IDs
+      const tagNames = (task.tags || []).map((tagId: string) => {
+        return data.tags[tagId]?.name || 'Unknown Tag';
       });
+
+      return {
+        id: String(task.id),
+        name: String(task.name),
+        note: String(task.note || ""),
+        flagged: Boolean(task.flagged),
+        completed: task.taskStatus === "Completed",
+        completionDate: null, // Not available in the new format
+        dropDate: null, // Not available in the new format
+        taskStatus: String(task.taskStatus),
+        active: task.taskStatus !== "Completed" && task.taskStatus !== "Dropped",
+        addedDate: task.addedDate || null,
+        dueDate: task.dueDate,
+        deferDate: task.deferDate,
+        plannedDate: task.plannedDate,
+        estimatedMinutes: task.estimatedMinutes ? Number(task.estimatedMinutes) : null,
+        tags: task.tags || [],
+        tagNames: tagNames,
+        parentId: task.parentTaskID || null,
+        containingProjectId: task.projectID || null,
+        projectId: task.projectID || null,
+        childIds: task.children || [],
+        hasChildren: (task.children && task.children.length > 0) || false,
+        sequential: Boolean(task.sequential),
+        completedByChildren: Boolean(task.completedByChildren),
+        isRepeating: false, // Not available in the new format
+        repetitionMethod: null, // Not available in the new format
+        repetitionRule: null, // Not available in the new format
+        attachments: normalizeTaskAttachments(task.attachments, task.linkedFileURLs),
+        linkedFileURLs: task.linkedFileURLs || [],
+        notifications: [], // Default empty array
+        shouldUseFloatingTimeZone: false // Default value
+      };
+    });
+  }
+
+  // Process projects
+  if (data.projects) {
+    for (const [id, project] of Object.entries(data.projects)) {
+      database.projects[id] = {
+        id: String(project.id),
+        name: String(project.name),
+        addedDate: project.addedDate || null,
+        status: String(project.status),
+        folderID: project.folderID || null,
+        sequential: Boolean(project.sequential),
+        effectiveDueDate: project.effectiveDueDate,
+        effectiveDeferDate: project.effectiveDeferDate,
+        effectivePlannedDate: project.effectivePlannedDate,
+        dueDate: project.dueDate,
+        deferDate: project.deferDate,
+        plannedDate: project.plannedDate,
+        completedByChildren: Boolean(project.completedByChildren),
+        containsSingletonActions: Boolean(project.containsSingletonActions),
+        note: String(project.note || ""),
+        tasks: project.tasks || [],
+        flagged: false, // Default value
+        estimatedMinutes: null // Default value
+      };
     }
-    
-    // Process projects
-    if (data.projects) {
-      for (const [id, project] of Object.entries(data.projects)) {
-        database.projects[id] = {
-          id: String(project.id),
-          name: String(project.name),
-          status: String(project.status),
-          folderID: project.folderID || null,
-          sequential: Boolean(project.sequential),
-          effectiveDueDate: project.effectiveDueDate,
-          effectiveDeferDate: project.effectiveDeferDate,
-          effectivePlannedDate: project.effectivePlannedDate,
-          dueDate: project.dueDate,
-          deferDate: project.deferDate,
-          plannedDate: project.plannedDate,
-          completedByChildren: Boolean(project.completedByChildren),
-          containsSingletonActions: Boolean(project.containsSingletonActions),
-          note: String(project.note || ""),
-          tasks: project.tasks || [],
-          flagged: false, // Default value
-          estimatedMinutes: null // Default value
-        };
-      }
+  }
+
+  // Process folders
+  if (data.folders) {
+    for (const [id, folder] of Object.entries(data.folders)) {
+      database.folders[id] = {
+        id: String(folder.id),
+        name: String(folder.name),
+        parentFolderID: folder.parentFolderID || null,
+        status: String(folder.status),
+        projects: folder.projects || [],
+        subfolders: folder.subfolders || []
+      };
     }
-    
-    // Process folders
-    if (data.folders) {
-      for (const [id, folder] of Object.entries(data.folders)) {
-        database.folders[id] = {
-          id: String(folder.id),
-          name: String(folder.name),
-          parentFolderID: folder.parentFolderID || null,
-          status: String(folder.status),
-          projects: folder.projects || [],
-          subfolders: folder.subfolders || []
-        };
-      }
+  }
+
+  // Process tags
+  if (data.tags) {
+    for (const [id, tag] of Object.entries(data.tags)) {
+      database.tags[id] = {
+        id: String(tag.id),
+        name: String(tag.name),
+        parentTagID: tag.parentTagID || null,
+        active: Boolean(tag.active),
+        allowsNextAction: Boolean(tag.allowsNextAction),
+        tasks: tag.tasks || []
+      };
     }
-    
-    // Process tags
-    if (data.tags) {
-      for (const [id, tag] of Object.entries(data.tags)) {
-        database.tags[id] = {
-          id: String(tag.id),
-          name: String(tag.name),
-          parentTagID: tag.parentTagID || null,
-          active: Boolean(tag.active),
-          allowsNextAction: Boolean(tag.allowsNextAction),
-          tasks: tag.tasks || []
-        };
-      }
-    }
-    
-    return database;
+  }
+
+  return database;
+}
+
+// Main function to dump the database
+export async function dumpDatabase(): Promise<OmnifocusDatabase> {
+
+  try {
+    // Execute the OmniFocus script
+    const data = await executeOmniFocusScript('@omnifocusDump.js') as OmnifocusDumpData;
+    // wait 1 second
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    return normalizeOmnifocusDumpData(data);
   } catch (error) {
     console.error("Error in dumpDatabase:", error);
     throw error;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface OmnifocusTask {
     active: boolean;
     
     // Dates
+    addedDate: string | null;
     dueDate: string | null;
     deferDate: string | null;
     plannedDate: string | null;
@@ -74,6 +75,7 @@ export interface OmnifocusProject {
   effectiveDueDate: string | null;
   effectiveDeferDate: string | null;
   effectivePlannedDate: string | null;
+  addedDate: string | null;
   dueDate: string | null;
   deferDate: string | null;
   plannedDate: string | null;

--- a/src/utils/omnifocusScripts/omnifocusDump.js
+++ b/src/utils/omnifocusScripts/omnifocusDump.js
@@ -8,6 +8,26 @@
           if (!date) return null;
           return date.toISOString();
         }
+
+        function getAddedDate(object) {
+          try {
+            if (object.added) {
+              return formatDate(object.added);
+            }
+          } catch {
+            // Continue to root-task fallback for objects that expose added elsewhere.
+          }
+
+          try {
+            if (object.task && object.task.added) {
+              return formatDate(object.task.added);
+            }
+          } catch {
+            // Fall through to null.
+          }
+
+          return null;
+        }
     
         // Helper function to safely get enum values - Simplified with direct mapping
         const taskStatusMap = {
@@ -98,6 +118,7 @@
             const projectData = {
               id: projectId,
               name: project.name,
+              addedDate: getAddedDate(project),
               status: getEnumValue(project.status, projectStatusMap),
               folderID: project.parentFolder ? project.parentFolder.id.primaryKey : null,
               sequential: project.task.sequential || false,
@@ -189,6 +210,7 @@
               const taskData = {
                 id: task.id.primaryKey,
                 name: task.name,
+                addedDate: getAddedDate(task),
                 note: task.note || "",
                 taskStatus: getEnumValue(task.taskStatus, taskStatusMap),
                 flagged: task.flagged,


### PR DESCRIPTION
## Summary

Add `addedDate` support to `dump_database` for OmniFocus tasks and projects.

The OmniFocus dump script now reads each item's `added` date, serializes it as an ISO 8601 string via `toISOString()`, preserves it through normalization, and shows it in compact reports as `[ADD:M/D]`.

Closes #33.

## Changes

- Add `addedDate` to task and project dump data.
- Read OmniFocus `added` dates in `omnifocusDump.js`.
- Add a `getAddedDate()` helper with a fallback for project-backed task objects.
- Add `addedDate` to shared task and project TypeScript types.
- Preserve `addedDate` in `normalizeOmnifocusDumpData()`.
- Render added dates in compact reports as `[ADD:M/D]`.
- Update the compact report legend to document the new `[ADD:M/D]` marker.
- Add tests for:
  - preserving task and project `addedDate` values
  - documenting that normalization passes through non-ISO `addedDate` strings without validation
  - rendering task and project added date markers in compact reports

## Behavior Notes

`addedDate` values generated by the OmniFocus dump script are ISO 8601 UTC strings, for example:

`2026-05-20T10:30:00.000Z`

The normalization layer does not validate externally supplied `addedDate` strings. It preserves the provided value when present, or uses `null` when missing.

## Testing

- `npm run build`
- `node --test dist/tools/dumpDatabase.test.js`