### PR TITLE
Preserve time-of-day in AppleScript date construction when the ISO includes a time

### DIFF
--- a/src/utils/dateFormatter.test.ts
+++ b/src/utils/dateFormatter.test.ts
@@ -30,3 +30,30 @@ test('appleScriptDateCode builds locale-independent date construction', () => {
 test('appleScriptDateCode rejects invalid variable names', () => {
   assert.throws(() => appleScriptDateCode('2026-02-28', 'invalid name'));
 });
+
+test('appleScriptDateCode preserves the wall-clock time when the ISO input includes T HH:MM(:SS)', () => {
+  const code = appleScriptDateCode('2026-08-05T18:30:45', 'dueDateValue');
+
+  assert.match(code, /set hours of dueDateValue to 18/);
+  assert.match(code, /set minutes of dueDateValue to 30/);
+  assert.match(code, /set seconds of dueDateValue to 45/);
+});
+
+test('appleScriptDateCode reads the time verbatim and ignores any UTC offset', () => {
+  // Wall-clock semantics: the offset is not applied, so the hour is taken as
+  // written regardless of the runner's timezone — consistent with how the date
+  // components are read straight from the string.
+  const code = appleScriptDateCode('2026-08-05T18:30:00+05:00', 'plannedDateValue');
+
+  assert.match(code, /set hours of plannedDateValue to 18/);
+  assert.match(code, /set minutes of plannedDateValue to 30/);
+  assert.match(code, /set seconds of plannedDateValue to 0/);
+});
+
+test('appleScriptDateCode keeps date-only input at midnight', () => {
+  const code = appleScriptDateCode('2026-08-05', 'deferDateValue');
+
+  assert.match(code, /set hours of deferDateValue to 0/);
+  assert.match(code, /set minutes of deferDateValue to 0/);
+  assert.match(code, /set seconds of deferDateValue to 0/);
+});

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -80,13 +80,34 @@ export function appleScriptDateCode(isoDate: string, variableName: string): stri
 
   const [, year, month, day] = match;
 
+  // Preserve the wall-clock time when the ISO input includes one, reading the
+  // hour/minute/second straight from the string exactly as the date components
+  // above are read. The time is taken verbatim, with no timezone conversion, so
+  // it stays consistent with the locale-independent date construction; any
+  // offset or "Z" suffix is ignored. Date-only input keeps hours/minutes/seconds
+  // at zero (midnight), leaving the original behavior untouched.
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+  const timeMatch = /T(\d{2}):(\d{2})(?::(\d{2}))?/.exec(isoDate.trim());
+  if (timeMatch) {
+    const parsedHours = Number(timeMatch[1]);
+    const parsedMinutes = Number(timeMatch[2]);
+    const parsedSeconds = timeMatch[3] ? Number(timeMatch[3]) : 0;
+    if (parsedHours <= 23 && parsedMinutes <= 59 && parsedSeconds <= 59) {
+      hours = parsedHours;
+      minutes = parsedMinutes;
+      seconds = parsedSeconds;
+    }
+  }
+
   return `
     set ${variableName} to current date
     set day of ${variableName} to 1
     set year of ${variableName} to ${Number(year)}
     set month of ${variableName} to ${Number(month)}
     set day of ${variableName} to ${Number(day)}
-    set hours of ${variableName} to 0
-    set minutes of ${variableName} to 0
-    set seconds of ${variableName} to 0`;
+    set hours of ${variableName} to ${hours}
+    set minutes of ${variableName} to ${minutes}
+    set seconds of ${variableName} to ${seconds}`;
 }


### PR DESCRIPTION
`appleScriptDateCode` hardcoded hours/minutes/seconds to `0`, so any `plannedDate`/`dueDate`/`deferDate` lost its time-of-day and fell to local midnight.

This reads the hour/minute/second **straight from the ISO string** when it includes `T HH:MM(:SS)`, exactly as the year/month/day are already read. The time is taken verbatim, with **no timezone conversion** — any offset or `Z` suffix is ignored — so it stays consistent with the locale-independent, component-based date construction and never lets the day (read from the string) and the time drift apart. Date-only input still resolves to midnight, so the original behavior is untouched.

Adds timezone-independent unit tests: time preserved when the ISO carries `T HH:MM(:SS)`, offset ignored (wall-clock), and date-only input staying at midnight.
